### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action/ajax.php
+++ b/action/ajax.php
@@ -27,7 +27,7 @@ class action_plugin_nsexport_ajax extends DokuWiki_Action_Plugin {
     // ID from the export zip
     var $fileid;
 
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, 'handle_ajax_call');
     }
 

--- a/action/export.php
+++ b/action/export.php
@@ -16,7 +16,7 @@ class action_plugin_nsexport_export extends DokuWiki_Action_Plugin {
 
     var $run = false;
 
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('TPL_ACT_UNKNOWN','BEFORE',  $this, 'nsexport');
         $controller->register_hook('ACTION_ACT_PREPROCESS','BEFORE',  $this, 'act');
     }


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.